### PR TITLE
Add explicit API key documentation

### DIFF
--- a/R/rbraries-package.R
+++ b/R/rbraries-package.R
@@ -11,7 +11,7 @@
 #' key. 
 #' 
 #' You can pass the key into function calls, but that's not recommended.
-#' Store your key by putting in your .Renviron file or similar file like
+#' Store your key by putting a `LIBRARIES_IO_KEY` entry in your .Renviron file or similar file like
 #' e.g. .zshrc or .bash_profile, etc. We'll grab that key so that you 
 #' don't have to pass it into each function call.
 #' 

--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,7 @@ Settings page, then scroll down to API key section and grab your
 key. 
 
 You can pass the key into function calls, but that's not recommended.
-Store your key by putting in your .Renviron file or similar file like
+Store your key by putting a `LIBRARIES_IO_KEY` entry in your .Renviron file or similar file like
 e.g. .zshrc or .bash_profile, etc. We'll grab that key so that you 
 don't have to pass it into each function call.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minor change. I wanted to add my own API key but the `LIBRARIES_IO_KEY` variable name was not documented. While this may be easy enough to guess, I'm authenticated via GitHub which uses `GITHUB_PAT` in my `.Renviron`, so I had to dig through the source to figure out what to use.

